### PR TITLE
refactor: centralize quadra mapping for converters

### DIFF
--- a/conversor.py
+++ b/conversor.py
@@ -32,17 +32,12 @@ class Conversor:
                     print("\n")
                 return
             cidade = Palmas()
-            achou = False
-            for d in cidade.quadras:
-                for chave_0, valor_1 in d.items():
-                    if busca == chave_0:
-                        for i in range(50):
-                            print("\n")
-                        print(f"     🔎 Busca: {chave_0} | 📍 Resultado: {valor_1}")
-                        achou = True
-                if achou:
-                    break
-            if not achou:
+            resultado = cidade.get_mapa().get(busca)
+            if resultado:
+                for i in range(50):
+                    print("\n")
+                print(f"     🔎 Busca: {busca} | 📍 Resultado: {resultado}")
+            else:
                 for i in range(50):
                     print("\n")
                 print("             Endereço", busca, "inválido!")
@@ -75,17 +70,13 @@ class Conversor:
                     print("\n")
                 return     
             cidade = Palmas()
-            achou = False
-            for d in cidade.quadras:
-                for chave_0, valor_1 in d.items():
-                    if busca == valor_1:
-                        for i in range(50):
-                            print("\n")
-                        print(f"     🔎 Busca: {valor_1} | 📍 Resultado: {chave_0}")
-                        achou = True
-                if achou:
-                    break
-            if not achou:
+            mapa_inverso = {v: k for k, v in cidade.get_mapa().items()}
+            resultado = mapa_inverso.get(busca)
+            if resultado:
+                for i in range(50):
+                    print("\n")
+                print(f"     🔎 Busca: {busca} | 📍 Resultado: {resultado}")
+            else:
                 for i in range(50):
                     print("\n")
                 print("             Endereço", busca, "inválido!")

--- a/palmas.py
+++ b/palmas.py
@@ -213,3 +213,10 @@ class Palmas:
         }
 
         self.quadras = [self.arno, self.arne, self.arse, self.arso]
+
+    def get_mapa(self):
+        if not hasattr(self, "_mapa"):
+            self._mapa = {}
+            for quadra in self.quadras:
+                self._mapa.update(quadra)
+        return self._mapa


### PR DESCRIPTION
## Summary
- expose a combined quadra map through `Palmas.get_mapa`
- simplify `converter_para_numerado` and `converter_para_sigla` by using dictionary lookups

## Testing
- `python -m py_compile palmas.py conversor.py`
- `python - <<'PY'
from palmas import Palmas
p = Palmas()
mapa = p.get_mapa()
print('ARNO 13 ->', mapa.get('ARNO 13'))
mapa_inv = {v:k for k,v in mapa.items()}
print('107 Norte ->', mapa_inv.get('107 Norte'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689cabd74570832ea5cfd9842154b7b4